### PR TITLE
Security 수정

### DIFF
--- a/src/main/java/com/example/naejango/global/auth/dto/ReissueAccessTokenResponseDto.java
+++ b/src/main/java/com/example/naejango/global/auth/dto/ReissueAccessTokenResponseDto.java
@@ -1,0 +1,21 @@
+package com.example.naejango.global.auth.dto;
+
+import com.example.naejango.global.common.exception.ErrorCode;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@NoArgsConstructor
+@AllArgsConstructor
+@Builder
+public class ReissueAccessTokenResponseDto {
+    private String message;
+    private String accessToken;
+
+    public ReissueAccessTokenResponseDto(ErrorCode errorCode, String accessToken) {
+        this.message = errorCode.getMessage();
+        this.accessToken = accessToken;
+    }
+}

--- a/src/main/java/com/example/naejango/global/auth/filter/JwtAuthenticationFilter.java
+++ b/src/main/java/com/example/naejango/global/auth/filter/JwtAuthenticationFilter.java
@@ -1,7 +1,6 @@
 package com.example.naejango.global.auth.filter;
 
 import com.example.naejango.global.auth.jwt.JwtAuthenticator;
-import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.security.authentication.AuthenticationManager;
 import org.springframework.security.web.authentication.www.BasicAuthenticationFilter;
 
@@ -16,7 +15,6 @@ public class JwtAuthenticationFilter extends BasicAuthenticationFilter {
 
     private final JwtAuthenticator jwtAuthenticator;
 
-    @Autowired
     public JwtAuthenticationFilter(AuthenticationManager authenticationManager, JwtAuthenticator jwtAuthenticator) {
         super(authenticationManager);
         this.jwtAuthenticator = jwtAuthenticator;
@@ -30,7 +28,7 @@ public class JwtAuthenticationFilter extends BasicAuthenticationFilter {
      */
     @Override
     protected void doFilterInternal(HttpServletRequest request, HttpServletResponse response, FilterChain chain) throws IOException, ServletException {
-        jwtAuthenticator.jwtAuthenticate(request, response);
+        jwtAuthenticator.authenticateWithAccessToken(request);
         chain.doFilter(request, response);
     }
 }

--- a/src/main/java/com/example/naejango/global/auth/handler/OAuthLoginFailureHandler.java
+++ b/src/main/java/com/example/naejango/global/auth/handler/OAuthLoginFailureHandler.java
@@ -1,12 +1,17 @@
 package com.example.naejango.global.auth.handler;
 
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
 import org.springframework.security.core.AuthenticationException;
 import org.springframework.security.web.authentication.AuthenticationFailureHandler;
+import org.springframework.stereotype.Component;
 
 import javax.servlet.http.HttpServletRequest;
 import javax.servlet.http.HttpServletResponse;
 import java.io.IOException;
-
+@Component
+@RequiredArgsConstructor
+@Slf4j
 public class OAuthLoginFailureHandler implements AuthenticationFailureHandler {
     private final String redirectUrl = "https://naejango.site/oauth/KakaoCallback";
     private final String localRedirectUrl = "https://localhost:3000/oauth/kakaoCallback";

--- a/src/main/java/com/example/naejango/global/auth/handler/OAuthLoginFailureHandler.java
+++ b/src/main/java/com/example/naejango/global/auth/handler/OAuthLoginFailureHandler.java
@@ -1,0 +1,18 @@
+package com.example.naejango.global.auth.handler;
+
+import org.springframework.security.core.AuthenticationException;
+import org.springframework.security.web.authentication.AuthenticationFailureHandler;
+
+import javax.servlet.http.HttpServletRequest;
+import javax.servlet.http.HttpServletResponse;
+import java.io.IOException;
+
+public class OAuthLoginFailureHandler implements AuthenticationFailureHandler {
+    private final String redirectUrl = "https://naejango.site/oauth/KakaoCallback";
+    private final String localRedirectUrl = "https://localhost:3000/oauth/kakaoCallback";
+
+    @Override
+    public void onAuthenticationFailure(HttpServletRequest request, HttpServletResponse response, AuthenticationException exception) throws IOException {
+        response.sendRedirect(redirectUrl + "?failure");
+    }
+}

--- a/src/main/java/com/example/naejango/global/auth/handler/OAuthLoginSuccessHandler.java
+++ b/src/main/java/com/example/naejango/global/auth/handler/OAuthLoginSuccessHandler.java
@@ -1,8 +1,8 @@
 package com.example.naejango.global.auth.handler;
 
 import com.example.naejango.domain.user.application.UserService;
+import com.example.naejango.global.auth.jwt.JwtCookieSetter;
 import com.example.naejango.global.auth.jwt.JwtGenerator;
-import com.example.naejango.global.auth.jwt.JwtProperties;
 import com.example.naejango.global.common.handler.CommonDtoHandler;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
@@ -10,7 +10,6 @@ import org.springframework.security.core.Authentication;
 import org.springframework.security.web.authentication.AuthenticationSuccessHandler;
 import org.springframework.stereotype.Component;
 
-import javax.servlet.http.Cookie;
 import javax.servlet.http.HttpServletRequest;
 import javax.servlet.http.HttpServletResponse;
 import java.io.IOException;
@@ -23,8 +22,9 @@ public class OAuthLoginSuccessHandler implements AuthenticationSuccessHandler {
     private final UserService userService;
     private final JwtGenerator jwtGenerator;
     private final CommonDtoHandler commonDtoHandler;
-    private final String redirectUrl = "http://localhost:3000/oauth/kakaoCallback";
-
+    private final JwtCookieSetter jwtCookieSetter;
+    private final String redirectUrl = "https://naejango.site/oauth/KakaoCallback";
+    private String localRedirectUrl = "https://localhost:3000/oauth/kakaoCallback";
 
     /**
      * OAuth 로그인 처리가 성공적으로 수행되어 Authentication 객체가 만들어 진 경우 실행되는 메서드.
@@ -38,29 +38,25 @@ public class OAuthLoginSuccessHandler implements AuthenticationSuccessHandler {
                 .findAny()
                 .ifPresentOrElse(
                         cookie -> {},
-                        () -> generateJWT(authentication, response)
+                        () -> generateAndSetTokenCookies(authentication, response)
                 );
-        response.sendRedirect(redirectUrl);
+
+        response.sendRedirect(localRedirectUrl);
     }
 
-    private void generateJWT(Authentication authentication, HttpServletResponse response) {
+    private void generateAndSetTokenCookies(Authentication authentication, HttpServletResponse response) {
         Long userId = commonDtoHandler.userIdFromAuthentication(authentication);
+
         String accessToken = jwtGenerator.generateAccessToken(userId);
         String refreshToken = jwtGenerator.generateRefreshToken(userId);
         userService.refreshSignature(userId, refreshToken);
 
-        Cookie accessTokenCookie = new Cookie(JwtProperties.ACCESS_TOKEN_COOKIE_NAME, accessToken);
-        Cookie refreshTokenCookie = new Cookie(JwtProperties.REFRESH_TOKEN_COOKIE_NAME, refreshToken);
-        accessTokenCookie.setHttpOnly(false); // 자바스크립트 접근 허용
-        refreshTokenCookie.setHttpOnly(true);
-        accessTokenCookie.setSecure(true);
-        refreshTokenCookie.setSecure(true);
-        accessTokenCookie.setDomain("naejango.site");
-        refreshTokenCookie.setDomain("naejango.site");
-        accessTokenCookie.setPath("/");
-        refreshTokenCookie.setPath("/");
-        response.addCookie(accessTokenCookie);
-        response.addCookie(refreshTokenCookie);
-    }
+        jwtCookieSetter.addAccessTokenCookie(accessToken, response);
+        jwtCookieSetter.addRefreshTokenCookie(refreshToken, response);
 
+        localRedirectUrl += ("?accesstoken=" + accessToken); // 로컬 개발환경을 위한 url
+    }
 }
+
+
+

--- a/src/main/java/com/example/naejango/global/auth/jwt/AccessTokenReissuer.java
+++ b/src/main/java/com/example/naejango/global/auth/jwt/AccessTokenReissuer.java
@@ -1,0 +1,41 @@
+package com.example.naejango.global.auth.jwt;
+
+import com.example.naejango.global.auth.dto.ValidateTokenResponseDto;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Component;
+
+import javax.servlet.http.Cookie;
+import javax.servlet.http.HttpServletRequest;
+import java.util.Arrays;
+
+@Component
+@RequiredArgsConstructor
+public class AccessTokenReissuer {
+
+    private final JwtValidator jwtValidator;
+    private final JwtGenerator jwtGenerator;
+
+    public String reissueAccessToken(HttpServletRequest request) {
+        String refreshToken = getRefreshToken(request);
+        if(refreshToken == null) return null;
+
+        ValidateTokenResponseDto validateResult = jwtValidator.validateRefreshToken(refreshToken);
+        if (!validateResult.isValidToken()) return null;
+
+        return jwtGenerator.generateAccessToken(validateResult.getUserId());
+    }
+
+    /**
+     * HttpServletRequest 에서 refresh token 을 가져오는 메서드
+     * refresh cookie 가 없는 경우 null 을 반환
+     */
+    private String getRefreshToken(HttpServletRequest request) {
+        Cookie[] cookies = request.getCookies();
+        if (cookies == null) return null;
+        return Arrays.stream(cookies).filter(cookie -> cookie.getName().equals(JwtProperties.REFRESH_TOKEN_COOKIE_NAME))
+                .map(Cookie::getValue)
+                .findAny()
+                .orElse(null);
+    }
+
+}

--- a/src/main/java/com/example/naejango/global/auth/jwt/JwtCookieSetter.java
+++ b/src/main/java/com/example/naejango/global/auth/jwt/JwtCookieSetter.java
@@ -1,0 +1,49 @@
+package com.example.naejango.global.auth.jwt;
+
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Component;
+
+import javax.servlet.http.Cookie;
+import javax.servlet.http.HttpServletResponse;
+
+@Component
+@RequiredArgsConstructor
+public class JwtCookieSetter {
+
+    public void addAccessTokenCookie(String accessToken, HttpServletResponse response) {
+        Cookie refreshTokenCookie = new Cookie(JwtProperties.ACCESS_TOKEN_COOKIE_NAME, accessToken);
+        setRefreshTokenCookie(refreshTokenCookie);
+        response.addCookie(refreshTokenCookie);
+    }
+
+    public void addRefreshTokenCookie(String refreshToken, HttpServletResponse response) {
+        Cookie refreshTokenCookie = new Cookie(JwtProperties.REFRESH_TOKEN_COOKIE_NAME, refreshToken);
+        setRefreshTokenCookie(refreshTokenCookie);
+        response.addCookie(refreshTokenCookie);
+    }
+
+    public void deleteAccessTokenCookie(Cookie accessTokenCookie, HttpServletResponse response) {
+        setAccessTokenCookie(accessTokenCookie);
+        accessTokenCookie.setMaxAge(0);
+        response.addCookie(accessTokenCookie);
+    }
+    public void deleteRefreshTokenCookie(Cookie refreshTokenCookie, HttpServletResponse response) {
+        setRefreshTokenCookie(refreshTokenCookie);
+        refreshTokenCookie.setMaxAge(0);
+        response.addCookie(refreshTokenCookie);
+    }
+
+    private void setRefreshTokenCookie(Cookie refreshTokenCookie) {
+        refreshTokenCookie.setHttpOnly(true);
+        refreshTokenCookie.setSecure(true);
+        refreshTokenCookie.setDomain("naejango.site");
+        refreshTokenCookie.setPath("/");
+    }
+
+    private void setAccessTokenCookie(Cookie accessTokenCookie) {
+        accessTokenCookie.setHttpOnly(false);
+        accessTokenCookie.setSecure(true);
+        accessTokenCookie.setDomain("naejango.site");
+        accessTokenCookie.setPath("/");
+    }
+}

--- a/src/main/java/com/example/naejango/global/auth/principal/PrincipalDetails.java
+++ b/src/main/java/com/example/naejango/global/auth/principal/PrincipalDetails.java
@@ -1,5 +1,6 @@
 package com.example.naejango.global.auth.principal;
 
+import com.example.naejango.domain.user.domain.Role;
 import com.example.naejango.domain.user.domain.User;
 import lombok.Getter;
 import org.springframework.security.core.GrantedAuthority;
@@ -13,6 +14,10 @@ import java.util.Map;
 @Getter
 public class PrincipalDetails implements UserDetails, OAuth2User {
     private final User user;
+
+    public Role getRole() {
+        return this.user.getRole();
+    }
 
     public PrincipalDetails(User user) {
         this.user = user;
@@ -30,10 +35,9 @@ public class PrincipalDetails implements UserDetails, OAuth2User {
 
     @Override
     public Collection<? extends GrantedAuthority> getAuthorities() {
-        Collection<GrantedAuthority> collect = new ArrayList<>();
-        collect.add((GrantedAuthority) () -> "ROLE_" + user.getRole().toString());
-        return collect;
+        return new ArrayList<>();
     }
+
 
     @Override
     public String getPassword() {

--- a/src/main/java/com/example/naejango/global/common/api/HealthCheck.java
+++ b/src/main/java/com/example/naejango/global/common/api/HealthCheck.java
@@ -6,9 +6,14 @@ import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.RestController;
 
+import javax.sql.DataSource;
+import java.sql.Connection;
+import java.sql.SQLException;
+
 @RestController
 @RequiredArgsConstructor
 public class HealthCheck {
+    private final DataSource dataSource;
     private final DataSourceProperties dataSourceProperties;
 
     /** EC2 서버 접속 테스트를 위한 임시 API */
@@ -17,11 +22,20 @@ public class HealthCheck {
         return ResponseEntity.status(HttpStatus.OK).body(null);
     }
 
-    @GetMapping("/dbcheck")
-    public String DBCheck() {
-        String driverClassName = dataSourceProperties.getDriverClassName();
-        String url = dataSourceProperties.getUrl();
-        return "DBtype = " + driverClassName + "</br>" +
-                "url = " + url;
+    @GetMapping("/DBconnection")
+    public String DBConnectionCheck() {
+        try {
+            Connection connection = dataSource.getConnection();
+            if (connection != null) {
+                return "<h1>DB 연결 성공<h1>" +
+                        "DBtype = " + dataSourceProperties.getDriverClassName() + "</br>" +
+                        "url = " + dataSourceProperties.getUrl();
+
+            } else {
+                return "DB 연결 실패 " ;
+            }
+        } catch (SQLException e) {
+            return "DB 연결 오류: " + e.getMessage();
+        }
     }
 }

--- a/src/main/java/com/example/naejango/global/common/exception/ErrorCode.java
+++ b/src/main/java/com/example/naejango/global/common/exception/ErrorCode.java
@@ -10,16 +10,22 @@ public enum ErrorCode {
     TRANSACTION_NOT_MODIFICATION(HttpStatus.BAD_REQUEST, "수정 할 수 없는 거래입니다."),
     TRANSACTION_NOT_DELETE(HttpStatus.BAD_REQUEST, "삭제 할 수 없는 거래입니다."),
 
-    /** 401 UNAUTHORIZED : 인증되지 않은 사용자 */
+    /** 401 UNAUTHORIZED : 권한 없음 */
+
+    UNAUTHORIZED(HttpStatus.UNAUTHORIZED, "요청 권한이 없습니다."),
 
     NOT_AUTHENTICATED(HttpStatus.UNAUTHORIZED, "로그인 되어 있지 않은 상태입니다."),
     INVALID_TOKEN_ACCESS(HttpStatus.UNAUTHORIZED, "액세스 토큰 복호화에 실패하였습니다."),
+    NOT_LOGGED_IN(HttpStatus.UNAUTHORIZED, "로그인이 필요한 요청입니다."),
+    ACCESSTOKEN_EXPIRED(HttpStatus.UNAUTHORIZED, "엑세스 토큰이 만료되어 재발급 합니다."),
+    SIGNUP_INCOMPLETE(HttpStatus.UNAUTHORIZED, "회원가입 절차가 완료되지 않은 회원입니다."),
 
     /** 403 FORBIDDEN : 사용자가 콘텐츠에 접근할 권리를 가지고 있지 않음 */
     UNAUTHORIZED_MODIFICATION_REQUEST(HttpStatus.FORBIDDEN, "수정 권한이 없습니다."),
     UNAUTHORIZED_DELETE_REQUEST(HttpStatus.FORBIDDEN, "삭제 권한이 없습니다."),
 
     /** 404 NOT_FOUND : 리소스를 찾을 수 없음 */
+    MESSAGE_NOT_FOUND(HttpStatus.NOT_FOUND, "메세지를 찾을 수 없습니다."),
     USER_NOT_FOUND(HttpStatus.NOT_FOUND, "해당하는 정보의 User를 찾을 수 없습니다."),
     CATEGORY_NOT_FOUND(HttpStatus.NOT_FOUND, "해당하는 정보의 Category를 찾을 수 없습니다."),
     STORAGE_NOT_FOUND(HttpStatus.NOT_FOUND, "해당하는 정보의 Storage를 찾을 수 없습니다."),

--- a/src/main/java/com/example/naejango/global/config/SecurityConfig.java
+++ b/src/main/java/com/example/naejango/global/config/SecurityConfig.java
@@ -2,6 +2,7 @@ package com.example.naejango.global.config;
 
 import com.example.naejango.global.auth.filter.JwtAuthenticationFilter;
 import com.example.naejango.global.auth.handler.AccessDeniedHandlerImpl;
+import com.example.naejango.global.auth.handler.OAuthLoginFailureHandler;
 import com.example.naejango.global.auth.handler.OAuthLoginSuccessHandler;
 import com.example.naejango.global.auth.jwt.JwtAuthenticator;
 import com.example.naejango.global.auth.principal.PrincipalOAuth2UserService;
@@ -16,21 +17,17 @@ import org.springframework.security.config.annotation.web.configuration.EnableWe
 import org.springframework.security.config.http.SessionCreationPolicy;
 import org.springframework.security.web.SecurityFilterChain;
 
+import static com.example.naejango.domain.user.domain.Role.*;
+
 @EnableWebSecurity
 @RequiredArgsConstructor
 public class SecurityConfig {
     private final PrincipalOAuth2UserService principalOauth2UserService;
-    private final OAuthLoginSuccessHandler oauthLoginSuccessHandler;
+    private final OAuthLoginSuccessHandler oAuthLoginSuccessHandler;
+    private final OAuthLoginFailureHandler oAuthLoginFailureHandler;
     private final AccessDeniedHandlerImpl accessDeniedHandler;
     private final JwtAuthenticator jwtAuthenticator;
     private final CorsConfig corsConfig;
-
-    // 상수 관리를 별도로 진행할지 검토 예정
-    private final String USER = "USER";
-    private final String ADMIN = "ADMIN";
-    private final String GUEST = "GUEST";
-    private final String TEMPORAL = "TEMPORAL";
-    private final String loginPage = "/api/auth/localtest";
 
     @Bean
     public AuthenticationManager authenticationManager(){
@@ -53,17 +50,17 @@ public class SecurityConfig {
                 .antMatchers("/api/auth/**")
                 .permitAll()
                 .antMatchers(HttpMethod.POST, "/api/user/profile")
-                .hasAnyRole(TEMPORAL, ADMIN)
+                .hasAnyRole(TEMPORAL.toString(), ADMIN.toString())
                 .antMatchers("/api/**")
-                .hasAnyRole(USER, ADMIN, GUEST)
+                .hasAnyRole(USER.toString(), ADMIN.toString(), GUEST.toString())
                 .anyRequest().permitAll()
                 .and()
                 .oauth2Login()
-                .loginPage(loginPage)
                 .userInfoEndpoint()
                 .userService(principalOauth2UserService)
                 .and()
-                .successHandler(oauthLoginSuccessHandler);
+                .successHandler(oAuthLoginSuccessHandler)
+                .failureHandler(oAuthLoginFailureHandler);
         return http.build();
     }
 }


### PR DESCRIPTION
1.
RefreshToken 으로 로그인이 가능하게 로직이 짜여져 있는 오류가 있었습니다.
Refresh Token 이 AccessToken 재발급만을 위한 용도로 쓰이도록 수정하였습니다.
이 과정에서 JwtAuthenticator 의 코드를 분리하였습니다.

2.
요청에 대한 권한이 없는 경우(Authenticate 실패 등)
케이스 별로 각각 다른 메세지와 dto를 반환하도록 수정하였습니다.


3.
그 외 쿠키 생성 방식 수정,
로컬 개발 환경을 고려한 리다이렉트 url 수정 등
자잘한 수정 사항이 있습니다. 